### PR TITLE
Fix broken require in repl

### DIFF
--- a/result.js
+++ b/result.js
@@ -205,6 +205,11 @@ const methodToFunction = function (method) {
 };
 
 Object.keys(methods).forEach(function (key) {
+    // Breaks require in repl
+    if (key === "inspect") {
+      return
+    }
+
     var method = methods[key];
     module.exports[key] = methodToFunction(method);
 });

--- a/result.js
+++ b/result.js
@@ -205,9 +205,9 @@ const methodToFunction = function (method) {
 };
 
 Object.keys(methods).forEach(function (key) {
-    // Breaks require in repl
+    // NOTE(bbqsrc): Breaks require in repl
     if (key === "inspect") {
-      return
+      return;
     }
 
     var method = methods[key];


### PR DESCRIPTION
Doing `require("r-result")` in the repl will error out due to trying to run `inspect` function on the `module.exports` object.
